### PR TITLE
Review1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The tool allows you to download, extract, install, start, stop, create, and drop
 Download and extract MariaDB portable version from a given URL.
 
 ```sh
-msnoisedb download_and_extract C:/path/to/extract/to
+msnoisedb download-and-extract C:/path/to/extract/to
 ```
 
 ### 2. Install MariaDB
@@ -61,7 +61,7 @@ msnoisedb download_and_extract C:/path/to/extract/to
 Install MariaDB by specifying the port (default is 3307).
 
 ```sh
-msnoisedb install_db
+msnoisedb install-db
 ```
 
 ### 3. Start MariaDB Server
@@ -69,7 +69,7 @@ msnoisedb install_db
 Start the MariaDB server in the background.
 
 ```sh
-msnoisedb start_server
+msnoisedb start-server
 ```
 
 ### 4. Stop MariaDB Server
@@ -77,7 +77,7 @@ msnoisedb start_server
 Stop the running MariaDB server.
 
 ```sh
-msnoisedb stop_server
+msnoisedb stop-server
 ```
 
 ### 5. Create a New Database
@@ -85,7 +85,7 @@ msnoisedb stop_server
 Create a new database.
 
 ```sh
-msnoisedb create_database DATABASE_NAME
+msnoisedb create-database DATABASE_NAME
 ```
 
 ### 6. Drop an Existing Database
@@ -93,7 +93,7 @@ msnoisedb create_database DATABASE_NAME
 Drop an existing database.
 
 ```sh
-msnoisedb drop_database DATABASE_NAME
+msnoisedb drop-database DATABASE_NAME
 ```
 
 ## Environment Variable

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The tool allows you to download, extract, install, start, stop, create, and drop
 
 ## Prerequisites
 
-- Python 3.6 or above.
+- Python 3.7 or above.
 - `click` package: Install using `pip install click`.
 - `requests` package: Install using `pip install requests`.
 - `psutil` package: Install using `pip install psutil`.

--- a/msnoise_db/cli.py
+++ b/msnoise_db/cli.py
@@ -57,7 +57,6 @@ def download_and_extract(extract_to):
     click.echo(f"Extracted to: {mariadb_dir}")
     with open(MARIADB_PATH, 'w') as f:
         f.write(mariadb_dir)
-    os.environ["MARIADB_DIR"] = mariadb_dir
 
     tmpdir = os.path.join(mariadb_dir, "tmp")
     datadir = os.path.join(mariadb_dir, "data")

--- a/msnoise_db/cli.py
+++ b/msnoise_db/cli.py
@@ -55,6 +55,8 @@ def download_and_extract(extract_to):
         raise click.BadParameter("Unsupported file format. Only .zip and .tar.gz are supported.")
     mariadb_dir = os.path.abspath(glob.glob(os.path.join(extract_to, "mariadb-11.5.2-*"))[0])
     click.echo(f"Extracted to: {mariadb_dir}")
+    with open(MARIADB_PATH, 'w') as f:
+        f.write(mariadb_dir)
     os.environ["MARIADB_DIR"] = mariadb_dir
 
     tmpdir = os.path.join(mariadb_dir, "tmp")

--- a/msnoise_db/cli.py
+++ b/msnoise_db/cli.py
@@ -55,8 +55,7 @@ def download_and_extract(extract_to):
         raise click.BadParameter("Unsupported file format. Only .zip and .tar.gz are supported.")
     mariadb_dir = os.path.abspath(glob.glob(os.path.join(extract_to, "mariadb-11.5.2-*"))[0])
     click.echo(f"Extracted to: {mariadb_dir}")
-    with open(MARIADB_PATH, 'w') as f:
-        f.write(mariadb_dir)
+    os.environ["MARIADB_DIR"] = mariadb_dir
 
     tmpdir = os.path.join(mariadb_dir, "tmp")
     datadir = os.path.join(mariadb_dir, "data")

--- a/msnoise_db/cli.py
+++ b/msnoise_db/cli.py
@@ -117,12 +117,10 @@ def start_server():
     data_dir = os.path.join(mariadb_dir, 'data')
     if system == "Windows":
         mysqld_cmd = os.path.join(bin_dir, 'mariadbd')
-        process = subprocess.Popen([mysqld_cmd, '--defaults-file='+ CONFIG_FILE], stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
     else:
         mysqld_cmd = os.path.join(bin_dir, "mariadbd-safe")
-        process = subprocess.Popen([mysqld_cmd, '--defaults-file='+ CONFIG_FILE], stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
+    process = subprocess.Popen([mysqld_cmd, '--defaults-file='+ CONFIG_FILE], stdout=subprocess.DEVNULL,
+                                   stderr=subprocess.DEVNULL, preexec_fn=os.setpgrp)
     if process.returncode:
         print(process.stdout.read())
         print(process.stderr.read())


### PR DESCRIPTION
I mainly change readme file for some typo and cli.py because  ```start-server``` wasn't staying active in background (with ```ps aux |grep mariadb```), now only killed by ```stop-server``` and not by itself 